### PR TITLE
fix: handle invalid authorization for web client

### DIFF
--- a/app/core/account.py
+++ b/app/core/account.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from dataclasses import dataclass
 
 from app.core.exceptions import (
+    ClaudeAuthenticationError,
     ClaudeRateLimitedError,
     OAuthAuthenticationNotAllowedError,
     OrganizationDisabledError,
@@ -80,6 +81,12 @@ class Account:
         ):
             self.status = AccountStatus.RATE_LIMITED
             self.resets_at = exc_val.resets_at
+            self.save()
+
+        if exc_type is ClaudeAuthenticationError and isinstance(
+            exc_val, ClaudeAuthenticationError
+        ):
+            self.status = AccountStatus.INVALID
             self.save()
 
         if exc_type is OrganizationDisabledError and isinstance(

--- a/app/core/external/claude_client.py
+++ b/app/core/external/claude_client.py
@@ -13,6 +13,7 @@ from app.core.http_client import (
 
 from app.core.config import settings
 from app.core.exceptions import (
+    ClaudeAuthenticationError,
     ClaudeRateLimitedError,
     CloudflareBlockedError,
     OrganizationDisabledError,
@@ -103,6 +104,9 @@ class ClaudeWebClient:
                 and error_message == "This organization has been disabled."
             ):
                 raise OrganizationDisabledError()
+
+            if response.status_code == 403 and error_message == "Invalid authorization":
+                raise ClaudeAuthenticationError()
 
             if response.status_code == 429:
                 try:


### PR DESCRIPTION
使用中发现有些 Cookie 已经失效了，但是没被检测标记成 Invalid，导致之后还会反复尝试

```
2025-07-28 12:33:20.814 | ERROR    | app.processors.claude_ai.pipeline:process:78 - Pipeline processing failed: ClaudeHttpError(error_code=503130, message_key='claudeClient.httpError', status_code=403, context={'url': 'https://claude.ai/api/organizations/e86d8ddb-c0c1-4ef6-be86-cd0d6393024f/chat_conversations', 'status_code': 403, 'error_type': 'permission_error', 'error_message': 'Invalid authorization'})
2025-07-28 12:33:20.814 | WARNING  | app.utils.retry:log_before_sleep:19 - Retrying create_message after attempt 1 due to ClaudeHttpError: ClaudeHttpError(error_code=503130, message_key='claudeClient.httpError', status_code=403, context={'url': 'https://claude.ai/api/organizations/e86d8ddb-c0c1-4ef6-be86-cd0d6393024f/chat_conversations', 'status_code': 403, 'error_type': 'permission_error', 'error_message': 'Invalid authorization'})
2025-07-28 12:33:23.721 | ERROR    | app.processors.claude_ai.pipeline:process:78 - Pipeline processing failed: ClaudeHttpError(error_code=503130, message_key='claudeClient.httpError', status_code=403, context={'url': 'https://claude.ai/api/organizations/ee98b6b9-a3d9-4463-bc2b-7ff89827e4c1/chat_conversations', 'status_code': 403, 'error_type': 'permission_error', 'error_message': 'Invalid authorization'})
2025-07-28 12:33:23.722 | WARNING  | app.utils.retry:log_before_sleep:19 - Retrying create_message after attempt 2 due to ClaudeHttpError: ClaudeHttpError(error_code=503130, message_key='claudeClient.httpError', status_code=403, context={'url': 'https://claude.ai/api/organizations/ee98b6b9-a3d9-4463-bc2b-7ff89827e4c1/chat_conversations', 'status_code': 403, 'error_type': 'permission_error', 'error_message': 'Invalid authorization'})
2025-07-28 12:33:26.157 | ERROR    | app.processors.claude_ai.pipeline:process:78 - Pipeline processing failed: ClaudeHttpError(error_code=503130, message_key='claudeClient.httpError', status_code=403, context={'url': 'https://claude.ai/api/organizations/de262c67-7ead-4b53-8c2b-0b8382930fa6/chat_conversations', 'status_code': 403, 'error_type': 'permission_error', 'error_message': 'Invalid authorization'})
2025-07-28 12:33:26.157 | WARNING  | app.core.error_handler:handle_app_exception:71 - AppException: ClaudeHttpError - Code: 503130, Message: HTTP error occurred when calling Claude AI: permission_error - Invalid authorization (Status: 403), Context: {'url': 'https://claude.ai/api/organizations/de262c67-7ead-4b53-8c2b-0b8382930fa6/chat_conversations', 'status_code': 403, 'error_type': 'permission_error', 'error_message': 'Invalid authorization'}
INFO:     172.17.0.1:59958 - "POST /v1/messages HTTP/1.1" 403 Forbidden
```