### PR TITLE
 fix: 修改.dockerignore 以修复 Docker 构建失败因为前端 node_modules 符号链接问题

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,7 +54,7 @@ venv.bak/
 .envrc
 
 # Node.js / Frontend
-node_modules/
+**/node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
## Summary
  - 修复 Docker 构建时 `Cannot find module 'typescript/bin/tsc'` 错误
  - 将 `.dockerignore` 中的 `node_modules/` 改为 `**/node_modules/`

  ## Problem
  Docker 构建流程：
  1. `pnpm install` 在容器中正确安装依赖
  2. `COPY front/ ./` 意外复制了本地 Windows 的 `front/node_modules/`
  3. pnpm 的符号链接（指向 `C:/program/...`）在 Linux 容器中断开
  4. `pnpm run build` 执行 `tsc` 时找不到模块

  根本原因：`.dockerignore` 的 `node_modules/` 规则仅匹配根目录，不匹配 `front/node_modules/`