### PR TITLE
fix(streaming): 修复 refusal 响应导致的错误日志并添加友好提示

### DIFF
--- a/app/models/streaming.py
+++ b/app/models/streaming.py
@@ -41,7 +41,7 @@ Delta = Union[TextDelta, InputJsonDelta, ThinkingDelta, SignatureDelta]
 class MessageDeltaData(BaseModel):
     model_config = ConfigDict(extra="allow")
     stop_reason: Optional[
-        Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"]
+        Literal["end_turn", "max_tokens", "stop_sequence", "tool_use", "pause_turn", "refusal"]
     ] = None
     stop_sequence: Optional[str] = None
 


### PR DESCRIPTION
## Summary

  修复 Claude.ai 返回 `stop_reason: "refusal"` 时的空回复问题，并添加友好的错误提示。

  ## Background

  ### 问题发现

  在使用 Sonnet 4.5 时，发送某些特定内容（如 `Q29kZQ==`）会触发 Claude.ai 的安全过滤器，
  返回 `stop_reason: "refusal"` 响应。此时：

  1. 服务端产生大量 `IndexError` 错误日志
  2. 客户端收到空回复，用户不知道发生了什么

  ### 根本原因

  **正常响应的事件流：**
  message_start → content_block_start → content_block_delta(s) → content_block_stop → message_delta → message_stop

  **Refusal 响应的事件流：**
  message_start → content_block_stop → message_delta(stop_reason="refusal") → message_stop
&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;↑
&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;跳过了 content_block_start！

  当收到 `content_block_stop` 时，代码直接访问 `content[index]`，但由于没有
  `content_block_start`，content 数组为空，导致 `IndexError`。

  ### Claude.ai 网页版的处理方式

  Claude.ai 网页版在遇到 refusal 时会显示友好提示：
  > "Chat paused: Sonnet 4.5's safety filters flagged this chat..."

  ## Solution

  ### 1. 补全模型定义

  `app/models/streaming.py` 中 `MessageDeltaData.stop_reason` 补充缺失的类型：
  - 添加 `"pause_turn"`
  - 添加 `"refusal"`

  使其与 `Message.stop_reason` 保持一致。

  ### 2. 添加边界检查

  `app/processors/claude_ai/message_collector_processor.py` 中 `ContentBlockStopEvent`
  处理添加边界检查，避免访问空数组产生错误日志。

  ### 3. 注入友好错误提示

  检测到 `stop_reason == "refusal"` 且 `content` 为空时，注入 `ErrorEvent`：

  ```json
  {
    "type": "error",
    "error": {
      "type": "refusal",
      "message": "Chat paused: Claude's safety filters flagged this message. This occasionally happens with normal, safe
  messages. Try rephrasing or using a different model."
    }
  }
```