### PR TITLE
chore(docker): add timezone configuration for Asia/Shanghai

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
     volumes:
       - ./data:/data
     environment:
+      # Timezone
+      - TZ=Asia/Shanghai
+
       # Server configuration
       - HOST=0.0.0.0
       - PORT=5201


### PR DESCRIPTION
发现部署的日志有点时间对不上，就给docker配置默认时区了。