### PR TITLE
fix: use plain HTTP client with claude-cli User-Agent for OAuth token exchange

### DIFF
--- a/app/core/http_client.py
+++ b/app/core/http_client.py
@@ -563,6 +563,45 @@ def create_session(
         )
 
 
+def create_plain_session(
+    timeout: int = settings.request_timeout,
+    proxy: Optional[str] = settings.proxy_url,
+    follow_redirects: bool = True,
+) -> AsyncSession:
+    """Create a plain HTTP session WITHOUT browser fingerprinting/impersonation.
+
+    Used for API endpoints (e.g. OAuth token exchange at console.anthropic.com)
+    that reject requests containing browser-injected headers (User-Agent, Origin,
+    TLS fingerprints) with 429 errors.
+
+    Prefers httpx (zero header injection). Falls back to curl_cffi or rnet
+    without impersonation if httpx is unavailable.
+    """
+    if HTTPX_AVAILABLE:
+        logger.debug("Using httpx as plain HTTP client")
+        return HttpxAsyncSession(
+            timeout=timeout,
+            proxy=proxy,
+            follow_redirects=follow_redirects,
+        )
+    elif CURL_CFFI_AVAILABLE:
+        logger.debug("Using curl_cffi (no impersonation) as plain HTTP client")
+        return CurlAsyncSessionWrapper(
+            timeout=timeout,
+            impersonate=None,
+            proxy=proxy,
+            follow_redirects=follow_redirects,
+        )
+    else:
+        logger.debug("Using rnet (no impersonation) as plain HTTP client")
+        return RnetAsyncSession(
+            timeout=timeout,
+            impersonate=None,
+            proxy=proxy,
+            follow_redirects=follow_redirects,
+        )
+
+
 async def download_image(url: str, timeout: int = 30) -> Tuple[bytes, str]:
     """Download an image from a URL and return content and content type.
 

--- a/app/services/oauth.py
+++ b/app/services/oauth.py
@@ -5,7 +5,7 @@ import time
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse, parse_qs
 
-from app.core.http_client import Response, create_session
+from app.core.http_client import Response, create_session, create_plain_session
 from loguru import logger
 
 from app.core.config import settings
@@ -53,6 +53,7 @@ class OAuthAuthenticator:
         }
 
     async def _request(self, method: str, url: str, **kwargs) -> Response:
+        """Browser-impersonating request — for claude.ai endpoints (Cloudflare)."""
         session = create_session(
             timeout=settings.request_timeout,
             impersonate="chrome",
@@ -76,6 +77,38 @@ class OAuthAuthenticator:
                 error_message="Error occurred during request to Claude.ai",
             )
 
+        return response
+
+    async def _token_request(self, url: str, data: dict) -> Response:
+        """Plain (non-impersonating) POST to the OAuth token endpoint.
+
+        console.anthropic.com/v1/oauth/token rejects requests that carry
+        browser fingerprinting headers (User-Agent, Origin, TLS JA3).
+        Using httpx here avoids the 429.
+        """
+        session = create_plain_session(
+            timeout=settings.request_timeout,
+            proxy=settings.proxy_url,
+            follow_redirects=False,
+        )
+        async with session:
+            response: Response = await session.request(
+                method="POST",
+                url=url,
+                data=data,
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": "claude-cli/2.1.81 (external, cli)",
+                },
+            )
+        if response.status_code != 200:
+            try:
+                error_body = await response.json()
+            except Exception:
+                error_body = "<non-JSON body>"
+            logger.error(
+                f"Token endpoint returned {response.status_code}: {error_body}"
+            )
         return response
 
     async def get_organization_info(self, cookie: str) -> Tuple[str, List[str]]:
@@ -209,12 +242,7 @@ class OAuthAuthenticator:
             data["state"] = state
 
         try:
-            response = await self._request(
-                "POST",
-                settings.oauth_token_url,
-                json=data,
-                headers={"Content-Type": "application/json"},
-            )
+            response = await self._token_request(settings.oauth_token_url, data)
 
             token_data = await response.json()
 
@@ -244,12 +272,7 @@ class OAuthAuthenticator:
         }
 
         try:
-            response = await self._request(
-                "POST",
-                settings.oauth_token_url,
-                json=data,
-                headers={"Content-Type": "application/json"},
-            )
+            response = await self._token_request(settings.oauth_token_url, data)
 
             if response.status_code != 200:
                 logger.error(f"Token refresh failed: {response.status_code}")


### PR DESCRIPTION
## Problem

OAuth token exchange to `console.anthropic.com/v1/oauth/token` returns 429 because Anthropic now rejects requests carrying browser fingerprinting headers (TLS JA3, browser User-Agent) or non-matching User-Agent values.

The current `exchange_token()` and `refresh_access_token()` use `_request()` which creates a session with `impersonate="chrome"`, triggering the rejection.

## Changes

- Add `create_plain_session()` in `http_client.py` — prefers httpx (no TLS fingerprinting), falls back to curl_cffi/rnet with `impersonate=None`
- Add `_token_request()` in `oauth.py` — uses the plain session with `Content-Type: application/x-www-form-urlencoded` and `User-Agent: claude-cli/2.1.81 (external, cli)`
- Switch `exchange_token()` and `refresh_access_token()` to use `_token_request()`

## What #51 was missing

PR #51 correctly identified the need for a plain HTTP session and `application/x-www-form-urlencoded` content type, but used `User-Agent: anthropic` which Anthropic also blanket-rejects with 429. Per the [opencode discussion](https://github.com/anomalyco/opencode/issues/18329), the token endpoint requires a User-Agent matching Claude Code's format (`claude-cli/<version> (external, cli)`).

## References

- https://github.com/anomalyco/opencode/issues/18329
- https://github.com/shahidshabbir-se/opencode-anthropic-oauth